### PR TITLE
Update FBMO License to be less restrictive

### DIFF
--- a/FBMO-LICENSE-v1.1.md
+++ b/FBMO-LICENSE-v1.1.md
@@ -1,0 +1,102 @@
+# FrozenBlock Modding Oasis License
+Version 1.1, April 2025
+
+Copyright (c) 2025 FrozenBlock Modding Oasis. All Rights Reserved.
+
+This License Agreement is made between the author(s) of the Software and any person or entity who obtains a copy of this Software and/or its associated files.
+
+By using the Software, the Licensee agrees to be bound by the terms and conditions of this Agreement.
+
+## 0. Summary
+This license allows nearly all uses for personal purposes, including modification and private sharing from official sources.
+
+The license protects authors' rights while maintaining some open-source qualities, such as accepting contributions and allowing code integration in non-competing projects.
+
+Public use is permitted with proper credit to the authors.
+
+Public redistribution and commercial use are prohibited.
+
+This license is derived from version 1.2 of the Supplementaries Team License, with permission given.
+
+## 1. Definitions
+For the purposes of this Agreement, the following definitions apply:
+
+- **Source Code** refers to source code of the Software, modified or not.
+
+- **Our Repositories** refers to "Source Code" of the Software that is hosted online and owned by the owners.
+
+- **Our Sources** refers to copies of the Software or its associated files obtained directly from the owners. This includes files available on the owners' official CurseForge or Modrinth project pages.
+
+- **Compete** refers to any project or software offering similar functionality, features, or services as the Software and targeting the same or a similar user base. This includes, but is not limited to, software that directly substitutes or mirrors one or more functionalities of the Software.
+
+- **Assets** refers to any non-code components of the Software, including but not limited to textures, models, sounds, icons, and other visual or auditory elements.
+
+### 1.1. Exemptions
+Cases indicated by each exemption defined below result indicate that a specific piece of the Software is not covered under this license.
+
+The exemptions to applicable definitions are as follows:
+
+- "Our Code" does not apply when it is explicitly indicated that the owners did not write the code. This may be indicated inside the code itself, or contained elsewhere within the project.
+- "Assets" does not apply when the owners were not involved in the creation of the asset.
+
+## 2. Grant of License
+Permissions are hereby granted below to any person having a copy of this software and/or its associated files:
+
+### 2.1. Usage
+The Software may be used for both private and public purposes as well integrated with your code as either a soft or hard dependency provided that it is downloaded from "Our Sources". 
+
+### 2.2. Copying
+The Software may be copied for private use or to contribute to its development.
+The Licensee may incorporate part of this "Source Code" into their own projects provided that:
+
+- Appropriate credit is given to the original authors of the Software.
+- The Licensee's project does not "Compete" with the Software.
+- "Assets" are exempt from this clause and require explicit premission.
+
+### 2.3. Modification
+The Software may be modified for private use or to contribute to its development.
+
+### 2.3. Publishing
+Public distribution or publication of the Software, in whole or in part, is strictly prohibited without the express written permission of the authors.
+
+### 2.4. Sharing
+The Licensee is permitted to share the Software privately with a limited number of individuals, such as friends or family members, provided that:
+
+- The sharing is done without any form of commercial gain or compensation.
+- The Software, in whole or in part, is not made publicly available or accessible to the general public.
+- The recipients of the Software agree to abide by the terms and conditions of this Agreement.
+
+### 2.5. Sub-Licensing
+The Licensee shall not, under any circumstances, sub-license, lease, rent, or otherwise transfer rights to the Software, in whole or in part, to any third party.
+
+### 2.6. Selling
+The sale of the Software, including its associated files, is strictly prohibited.
+
+## 3. Attribution
+Any public media produced by the Licensee (such as web pages or videos) that primarily focuses on the content of this Software must include explicit credits to the authors of the Software.
+Credits must include a link back to "Our Repositories".
+The Licensee may not claim ownership of the Software or its associated files.
+
+## 4. Contributions
+By submitting contributions (including but not limited to code, documentation, bug fixes, feature enhancements, or assets) to the Software, the contributor ("Contributor") agrees to the following terms:
+
+- **License Grant**: The Contributor hereby grants the Owner a perpetual, irrevocable, worldwide, non-exclusive, royalty-free license to use, reproduce, modify, adapt, publish, translate, create derivative works from, distribute, perform, and display such contributions, in whole or in part, in any form, medium, or technology now known or later developed. The Owner is also granted the right to sublicense these contributions as part of the Software.
+- **Warranty of Rights**: The Contributor represents and warrants that they have the right to make the contributions and that such contributions do not infringe on any third-party rights.
+
+For clarification, the above still allows the Contributor the right to relicense any content from their own direct contributions to the Software for use in any other projects, including their own, using any license they see fit, unless otherwise agreed upon with the Owner.
+
+## 5. Modpack Clarification
+Permission is granted for the Software to be used in Modpacks, provided that:
+
+- The Software used is an unmodified copy obtained from "Our Sources".
+- The Software is not directly bundled in the Modpack, as this would violate the redistribution clause.
+- Explicit credits within the Modpack are not required.
+
+## 6. Modification Clause
+In the event that Our Repositories for the Software have received no changes for a period exceeding one year, this license shall automatically convert to a Public Domain status.
+
+## 7. Disclaimer of Warranty
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## 8. Inclusion of Notices
+The above copyright notice and these permission notices must be included in all copies or substantial portions of the Software.


### PR DESCRIPTION
I’ve removed 2.7 as 2.2 is already good enough to stop theft, and 2.7 was incredibly harsh. Furthermore, I added a small clarification to 4.0 so that the average reader is more likely to understand that they still have the right to relicense their own contributions in other projects, even though that was allowed previously - it was simply added for readability.